### PR TITLE
Release v2.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '2.5.0'
 
 gem 'aws-sdk-s3', '~> 1.30.1'
 gem 'bcrypt', '~> 3.1.12'
-gem 'bootsnap', '~> 1.3.2', require: false
+gem 'coffee-rails', '~> 4.2.2'
 gem 'draper', '~> 3.0.1'
 gem 'figaro', '~> 1.1.1'
 gem 'jquery-rails', '~> 4.3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,8 +60,6 @@ GEM
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.3)
     bcrypt (3.1.12)
-    bootsnap (1.3.2)
-      msgpack (~> 1.0)
     builder (3.2.3)
     byebug (10.0.2)
     climate_control (0.2.0)
@@ -69,6 +67,13 @@ GEM
       json
       simplecov
       url
+    coffee-rails (4.2.2)
+      coffee-script (>= 2.2.0)
+      railties (>= 4.0.0)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.12.2)
     concurrent-ruby (1.1.4)
     crass (1.0.4)
     diff-lcs (1.3)
@@ -131,7 +136,6 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    msgpack (1.2.6)
     nio4r (2.3.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
@@ -269,9 +273,9 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-s3 (~> 1.30.1)
   bcrypt (~> 3.1.12)
-  bootsnap (~> 1.3.2)
   byebug (~> 10.0.2)
   codecov (~> 0.1.14)
+  coffee-rails (~> 4.2.2)
   draper (~> 3.0.1)
   factory_bot_rails (~> 4.11.1)
   faker (~> 1.9.1)


### PR DESCRIPTION
- Add `coffee-script-rails` gem back so Heroku can precompile assets